### PR TITLE
fix: Remove notification group that is failing the build

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -15,9 +15,6 @@ jobs:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
       branch: ${{ github.event.inputs.branch || 'master' }}
-      team_reviewers: "arbi-bom"
-      email_address: "arbi-bom@edx.org"
-      send_success_notification: false
     secrets:
       requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
       requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}


### PR DESCRIPTION
This group is failing the upgrade-python-requirements build and I keep getting notified about it. My solution is to remove the group. If someone would like to be notified, please make a PR to fix this issue. https://github.com/openedx/xblock-sql-grader/actions/runs/4190725541/jobs/7264421740 @feanil @UsamaSadiq @iamsobanjaved 