### PR TITLE
feat: standardize make extract_translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ package-lock.json
 sdk/
 venv/
 .idea/
+
+# Translations
+sql_grader/conf/locale/*/LC_MESSAGES/*

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ import re
 
 from setuptools import find_packages, setup
 
+README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
+
 
 def package_data(pkg, roots):
     """
@@ -96,6 +98,8 @@ setup(
     version='0.3.1',
     description='SQL Grader XBlock',  # TODO: write a better description.
     license='AGPLv3',
+    long_description=README,
+    long_description_content_type='text/x-rst',
     packages=find_packages(exclude=('sql_grader.tests')),
     install_requires=load_requirements('requirements/base.in'),
     entry_points={
@@ -110,6 +114,7 @@ setup(
             'scenarios/*.xml',
             'static',
             'templates/*.html',
+            'translations',
         ]
     ),
     classifiers=[

--- a/sql_grader/conf/locale/config.yaml
+++ b/sql_grader/conf/locale/config.yaml
@@ -1,0 +1,4 @@
+# Configuration for i18n workflow.
+
+locales:
+    - en  # English - Source Language

--- a/sql_grader/translations
+++ b/sql_grader/translations
@@ -1,0 +1,1 @@
+conf/locale


### PR DESCRIPTION
feat: standardize make extract_translations

This PR prepares the repository to comply with [openedx-translations](https://github.com/openedx/openedx-translations) by doing the following:

* Standardize the way `make extract_tranlations` work to comply with [openedx-translations](https://github.com/openedx/openedx-translations)

- [x] Tested on local devstack palm to ensure that everything renders fine
- [x] ~~Tested on local devstack palm to ensure that local translation still works~~ there is no local translation in this repo

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes

**For XBlocks:**
 - The standard translation path must be `conf/locale`. Therefore, we are creating a link from `conf/locale` to `translations` so Atlas can find the path without disrupting the current way of having translations locally within the XBlocks
 - [openedx-translations](https://github.com/openedx/openedx-translations) will have a related PR that adds the XBlock to the pipeline. This will not affect the current way of managing/updating translations
 - At the end of the project, a clear change log will be added and all translations will be handled by Atlas. Thus, the local translation will be removed from the repo within the version bump
 - A notification for the community will be published to ensure that everyone knows why translations directories are removed from all repos