### PR TITLE
build: Switch to ubuntu-latest for builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.8'
         - '3.11'
+        - '3.12'
         TOX_ENV:
         - csslint
         - eslint

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ def is_requirement(line):
 
 setup(
     name='xblock-sql-grader',
-    version='0.6.0',
+    version='1.0.0',
     description='SQL Grader XBlock',  # TODO: write a better description.
     license='AGPLv3',
     long_description=README,
@@ -154,7 +154,7 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = 
     csslint
     eslint
-    py{38, 311}-django{42}quality
+    py{311,312}-django{42},quality
 
 [testenv]
 deps = 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ envlist =
 [testenv]
 deps = 
     -rrequirements/test.txt
-    -e git+https://github.com/openedx/codejail.git@3.0.0\#egg=codejail
     django42: Django>=4.2,<4.3
     
 commands = 

--- a/tox.ini
+++ b/tox.ini
@@ -1,101 +1,101 @@
 [tox]
-envlist = 
+envlist =
     csslint
     eslint
     py{311,312}-django{42},quality
 
 [testenv]
-deps = 
+deps =
     -rrequirements/test.txt
     django42: Django>=4.2,<4.3
-    
-commands = 
+
+commands =
     coverage run manage.py test
     coverage report
     coverage html
 
 [testenv:clean]
-commands = 
+commands =
     coverage erase
 skip_install = True
 
 [testenv:csslint]
 allowlist_externals = {toxinidir}/node_modules/csslint/dist/cli.js
-passenv = 
+passenv =
     TRAVIS
     TRAVIS_JOB_ID
     TRAVIS_BRANCH
-commands = 
+commands =
     {toxinidir}/node_modules/csslint/dist/cli.js sql_grader/static/
-deps = 
+deps =
 skip_install = True
 
 [testenv:eslint]
 allowlist_externals = {toxinidir}/node_modules/eslint/bin/eslint.js
-passenv = 
+passenv =
     TRAVIS
     TRAVIS_JOB_ID
     TRAVIS_BRANCH
-commands = 
+commands =
     {toxinidir}/node_modules/eslint/bin/eslint.js sql_grader/static/view.js
-deps = 
+deps =
 skip_install = True
 
 [testenv:quality]
-passenv = 
+passenv =
     TRAVIS
     TRAVIS_JOB_ID
     TRAVIS_BRANCH
-deps = 
+deps =
     -rrequirements/quality.txt
-commands = 
+commands =
     pycodestyle sql_grader/
     pylint sql_grader/
 
 [testenv:translations_push]
-deps = 
+deps =
     transifex-client
-commands = 
+commands =
     tx push -s
 
 [testenv:translations_pull]
-deps = 
+deps =
     edx-i18n-tools==1.3.0
     transifex-client
-commands = 
+commands =
     cd sql_grader && i18n_tool transifex pull
-allowlist_externals = 
+allowlist_externals =
     cd
 
 [testenv:translations_compile]
-deps = 
+deps =
     edx-i18n-tools==1.3.0
-commands = 
+commands =
     cd sql_grader && i18n_tool generate
-allowlist_externals = 
+allowlist_externals =
     cd
 
 [testenv:translations_dummy]
-deps = 
+deps =
     edx-i18n-tools==1.3.0
-commands = 
+commands =
     cd sql_grader && i18n_tool dummy
-allowlist_externals = 
+allowlist_externals =
     cd
 
 [testenv:translations_detect_changed]
-deps = 
+deps =
     edx-i18n-tools==1.3.0
-commands = 
+commands =
     cd sql_grader && i18n_tool changed
-allowlist_externals = 
+allowlist_externals =
     cd
 
 [testenv:translations_extract]
-deps = 
+deps =
     edx-i18n-tools==1.3.0
-commands = 
+commands =
     cd sql_grader && i18n_tool extract
-allowlist_externals = 
+allowlist_externals =
     cd
 


### PR DESCRIPTION
This code does not have any dependencies that are specific to any specific
version of ubuntu.  So instead of testing on a specific version and then needing
to do work to keep the versions up-to-date, we switch to the ubuntu-latest
target which should be sufficient for testing purposes.

This work is being done as a part of https://github.com/openedx/platform-roadmap/issues/377
